### PR TITLE
remove division inside #{} on _begin.scss

### DIFF
--- a/_sass/_begin.scss
+++ b/_sass/_begin.scss
@@ -20,12 +20,12 @@ main {
 //
 // Fluid Typography
 //
-@mixin fluidType($min, $max ) {
+@mixin fluidType($min, $max) {
 	font-size: $min;
 
 	@media screen and (min-width: $minSupportedWidth) {
 		// 960 = 1280-320
-		font-size: calc(#{$min} + #{($max - $min)/1px} * ((100vw - 320px) / 960));
+		font-size: calc(#{$min} + ((#{$max - $min}) / 1px) * ((100vw - 320px) / 960));
 	}
 
 	@media screen and (min-width: $maxSupportedWidth) {


### PR DESCRIPTION
`bundle exec jekyll serve` produces this warning;
> Deprecation Warning: Using / for division outside of calc() is
> deprecated and will be removed in Dart Sass 2.0.0.

This commit removes division inside #{} on _begin.scss.